### PR TITLE
turn off snake case variable number rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,6 +146,8 @@ Metrics/CollectionLiteralLength: # new in 1.47
   Enabled: true
 Naming/BlockForwarding: # new in 1.24
   Enabled: true
+Naming/VariableNumber:
+  Enabled: false
 Security/CompoundHash: # new in 1.28
   Enabled: true
 Security/IoMethods: # new in 1.22


### PR DESCRIPTION
I want to switch off this rule that tells you
```ruby
# bad:
:spass_subscription_1

# good:
:spass_subscription1
```
this doesn't seem right.