### PR TITLE
Add test coverage for offense with multiple corrections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,24 @@ AllCops:
   Exclude:
     - 'test/rdjson_formatter/**/*'
     - 'vendor/**/*'
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
 Gemspec/AddRuntimeDependency: # new in 1.65
   Enabled: true
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30

--- a/test/rdjson_formatter/testdata/correctable_offenses.rb
+++ b/test/rdjson_formatter/testdata/correctable_offenses.rb
@@ -1,4 +1,4 @@
-def add(xyz,abc)
+def add xyz,abc
   a    = xyz+   abc;
   return  a
 end

--- a/test/rdjson_formatter/testdata/result.ok
+++ b/test/rdjson_formatter/testdata/result.ok
@@ -41,6 +41,42 @@
       ]
     },
     {
+      "message": "Use def with parentheses when there are parameters.",
+      "location": {
+        "path": "test/rdjson_formatter/testdata/correctable_offenses.rb",
+        "range": {
+          "start": {
+            "line": 1,
+            "column": 9
+          },
+          "end": {
+            "line": 1,
+            "column": 16
+          }
+        }
+      },
+      "severity": "INFO",
+      "code": {
+        "value": "Style/MethodDefParentheses"
+      },
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:1:9: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters.",
+      "suggestions": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            }
+          },
+          "text": "(xyz,abc)"
+        }
+      ]
+    },
+    {
       "message": "Space missing after comma.",
       "location": {
         "path": "test/rdjson_formatter/testdata/correctable_offenses.rb",


### PR DESCRIPTION
Adds a test to show that an offense with multiple corrections creates the right fix suggestion encompassing all corrections. Without the changes in the `fix-suggestions` branch, the suggestion for this offense is incomplete:
```json
{
  "message": "Use def with parentheses when there are parameters.",
  "location": {
    "path": "test/rdjson_formatter/testdata/correctable_offenses.rb",
    "range": {
      "start": {
        "line": 1,
        "column": 9
      },
      "end": {
        "line": 1,
        "column": 16
      }
    }
  },
  "severity": "INFO",
  "code": {
    "value": "Style/MethodDefParentheses"
  },
  "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:1:9: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters.",
  "suggestions": [
    {
      "range": {
        "start": {
          "line": 1,
          "column": 8
        },
        "end": {
          "line": 1,
          "column": 9
        }
      },
      "text": "("
    }
  ]
}
```