### PR TITLE
Add caching for RuboCop configuration to improve performance

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Get current hour for cache key
+      id: get-hour
+      run: echo "hour=$(date +'%Y%m%d%H')" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Cache RuboCop configuration
+      uses: actions/cache@v4
+      with:
+        path: |
+          .rubocop-https---*
+        key: rubocop-remote-config-${{ runner.os }}-${{ hashFiles('**/.rubocop*.yml') }}-${{ steps.get-hour.outputs.hour }}
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: sh
       env:


### PR DESCRIPTION
## Problem

<img width="1304" height="232" alt="Screenshot 2025-07-29 at 14 24 30" src="https://github.com/user-attachments/assets/eaf7c2eb-c71d-4337-a443-c7d2503fef95" />

RuboCop downloads remote configuration files on every action run, which can lead to:
- **429 rate limit errors** from remote config servers (primary issue)
- Performance degradation from repeated network requests
- Build failures when rate limits are exceeded

## Solution

Added GitHub Actions caching for RuboCop's downloaded remote configuration files:

### Cache Strategy
- **Cache path**: `.rubocop-https---*` (downloaded remote config files in working directory)
- **Cache key**: Includes OS, local config hash, and current hour
- **Expiry**: Strict 1-hour expiry (no fallback to older caches)

### Benefits
- ✅ **Prevents 429 rate limit errors** by reusing downloaded configs within the hour
- ✅ **Faster builds** by avoiding repeated network requests  
- ✅ **Fresh configs** ensured with hourly cache expiry
- ✅ **Reliable CI** without rate limit failures

### Cache Behavior
- **Within 1 hour**: Uses cached remote configs (avoids rate limits)
- **After 1 hour**: Downloads fresh configs (ensures updates propagate)
- **Config changes**: Cache invalidates immediately when local `.rubocop*.yml` files change

This addresses the root cause of 429 errors while maintaining config freshness.
